### PR TITLE
Fixed `flite` Engine build for recent Android NDK versions (using GCC 4.9) and add Build Script that simplifies the compilation process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
 libs/
+flite/
 gen/
 obj/
 build.properties

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -7,7 +7,7 @@
 
     <uses-sdk
         android:minSdkVersion="9"
-        android:targetSdkVersion="16" />
+        android:targetSdkVersion="22" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Installing this Application
 This app is not yet available on the Google Play Store, but you can
 generate an apk file by building this source code, or download an APK
 file from the Github page and install it on your device. Devices
-running Android versions 2.2 (Froyo) or later are supported.
+running Android versions 2.3 (Gingerbread) or later are supported.
 
 After installing this application, you will have to:
 
@@ -42,8 +42,32 @@ If you are developing an application and would like to use Flite for
 speech synthesis, you can specify "edu.cmu.cs.speech.tts.flite" as the
 package name of the engine to use.
 
-Building this App from Source
-=============================
+Building this App from Source using the Build script
+====================================================
+
+Instructions here are for development on Linux.
+
+Requirements
+------------
+In order to build this application, you need the following:
+
+- Android NDK Release 10e or newer
+- Android SDK with the SDK Platform package for Android 5.1.1 (API 22)
+
+Application Build Steps
+-----------------------
+
+*Export necessary environment variables* ::
+
+    export ANDROID_NDK=/path/to/android/ndk
+    export ANDROID_SDK=/path/to/android/sdk 
+
+*Wait for the build script do download, verify, extract, patch and build the Flite Engine and App.*
+
+The final ``apk`` will be placed in ``bin/FliteEngine-debug.apk``.
+
+Building this App from Source manually
+======================================
 
 Instructions here are for development on Linux.
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,145 @@
+#!/bin/sh
+FLITE_APP_DIR="$(dirname $(readlink -f "$0"))"
+FLITE_BUILD_DIR="${FLITE_APP_DIR}/flite"
+FLITE_ARCHIVE_URL="http://www.festvox.org/flite/packed/flite-2.0/flite-2.0.0-release.tar.bz2"
+FLITE_ARCHIVE_MD5="645db96ffc296cbb6d37f231cc1cc6b2"
+FLITE_ARCHIVE_NAM="$(basename "${FLITE_ARCHIVE_URL}")"
+FLITE_ARCHIVE_DIR="$(basename "${FLITE_ARCHIVE_URL}" .tar.bz2)"
+
+FLITE_PATCH='
+--- flite-2.0.0-release/configure.in	2014-12-09 22:39:01.000000000 +0100
++++ flite-2.0.0-release.new/configure.in	2016-06-15 12:36:53.543619329 +0200
+@@ -151,16 +151,22 @@
+                 # http://developer.android.com/sdk/ndk/index.html
+ 		shared=false
+ 
++		if test -z "${ANDROID_NDK}";
++		then
++			ANDROID_NDK="${ANDROID_NDK_HOME}"
++		fi
++
+ 		# We target our compilation to android-14 (4.0) platform
+ 		ANDROID_NDK_PLATFORM_PATH="$ANDROID_NDK/platforms/android-14"
+ 
+-		ANDROID_GCC_VERSION=4.6
++		ANDROID_GCC_ARCH="$(uname -m)"
++		ANDROID_GCC_VERSION=4.9
+ 
+ 		if test "$target_cpu" = "armeabi" 
+                 then
+ 		   ANDROID_TOOLCHAIN="arm-linux-androideabi-$ANDROID_GCC_VERSION"
+ 		   ANDROID_NDK_SYSROOT="$ANDROID_NDK_PLATFORM_PATH/arch-arm"
+-		   ANDROIDBIN="$ANDROID_NDK/toolchains/arm-linux-androideabi-$ANDROID_GCC_VERSION/prebuilt/linux-x86/bin/arm-linux-androideabi"
++		   ANDROIDBIN="$ANDROID_NDK/toolchains/arm-linux-androideabi-$ANDROID_GCC_VERSION/prebuilt/linux-$ANDROID_GCC_ARCH/bin/arm-linux-androideabi"
+       		   CFLAGS="$CFLAGS -fpic -mthumb -O3 -DANDROID --sysroot=$ANDROID_NDK_SYSROOT"
+                 fi
+ 
+@@ -168,7 +174,7 @@
+                 then
+ 		   ANDROID_TOOLCHAIN="arm-linux-androideabi-$ANDROID_GCC_VERSION"
+ 		   ANDROID_NDK_SYSROOT="$ANDROID_NDK_PLATFORM_PATH/arch-arm"
+-		   ANDROIDBIN="$ANDROID_NDK/toolchains/arm-linux-androideabi-$ANDROID_GCC_VERSION/prebuilt/linux-x86/bin/arm-linux-androideabi"
++		   ANDROIDBIN="$ANDROID_NDK/toolchains/arm-linux-androideabi-$ANDROID_GCC_VERSION/prebuilt/linux-$ANDROID_GCC_ARCH/bin/arm-linux-androideabi"
+       		   CFLAGS="$CFLAGS -fpic -march=armv7-a -mfloat-abi=softfp -O3 -DANDROID --sysroot=$ANDROID_NDK_SYSROOT"
+ 		   LDFLAGS="$LDFLAGS -Wl,--fix-cortex-a8"
+                 fi
+@@ -177,7 +183,7 @@
+ 		then
+ 		   ANDROID_TOOLCHAIN="x86-$ANDROID_GCC_VERSION"
+ 		   ANDROID_NDK_SYSROOT="$ANDROID_NDK_PLATFORM_PATH/arch-x86"
+-		   ANDROIDBIN="$ANDROID_NDK/toolchains/x86-$ANDROID_GCC_VERSION/prebuilt/linux-x86/bin/i686-linux-android"
++		   ANDROIDBIN="$ANDROID_NDK/toolchains/x86-$ANDROID_GCC_VERSION/prebuilt/linux-$ANDROID_GCC_ARCH/bin/i686-linux-android"
+       		   CFLAGS="$CFLAGS -fpic -O3 -DANDROID --sysroot=$ANDROID_NDK_SYSROOT"
+ 		fi
+ 
+@@ -185,7 +191,7 @@
+ 		then
+ 		   ANDROID_TOOLCHAIN="mipsel-linux-android-$ANDROID_GCC_VERSION"
+ 		   ANDROID_NDK_SYSROOT="$ANDROID_NDK_PLATFORM_PATH/arch-mips"
+-		   ANDROIDBIN="$ANDROID_NDK/toolchains/mipsel-linux-android-$ANDROID_GCC_VERSION/prebuilt/linux-x86/bin/mipsel-linux-android"
++		   ANDROIDBIN="$ANDROID_NDK/toolchains/mipsel-linux-android-$ANDROID_GCC_VERSION/prebuilt/linux-$ANDROID_GCC_ARCH/bin/mipsel-linux-android"
+       		   CFLAGS="$CFLAGS -fpic -O3 -DANDROID --sysroot=$ANDROID_NDK_SYSROOT"
+ 		fi
+';
+
+# Abort after first error
+set -e
+OLDPWD="${PWD}"
+
+# Check for required environment vairables
+HAVE_REQUIRED_ENVS=true
+
+if [ -z "${ANDROID_NDK}" ] && [ -z "${ANDROID_NDK_HOME}" ];
+then
+	echo "Missing Android NDK path environment variable: ANDROID_NDK / ANDROID_NDK_HOME" >&2
+	HAVE_REQUIRED_ENVS=false
+fi
+
+if [ -z "${ANDROID_SDK}" ] && [ -z "${ANDROID_HOME}" ];
+then
+	echo "Missing Android SDK path environment variable: ANDROID_SDK / ANDROID_HOME" >&2
+	HAVE_REQUIRED_ENVS=false
+fi
+
+if ! ${HAVE_REQUIRED_ENVS};
+then
+	exit 1
+fi
+
+export FLIGHT_APP_DIR
+
+# Download and patch flight, unless it was provided
+if [ -z "${FLITEDIR}" ];
+then
+	# Check if the actual `flight` build directory exists
+	flite_directory="${FLITE_BUILD_DIR}/${FLITE_ARCHIVE_DIR}"
+	if ! [ -d "${flite_directory}" ];
+	then
+		mkdir -p "${FLITE_BUILD_DIR}"
+		
+		flite_archive="${FLITE_BUILD_DIR}/${FLITE_ARCHIVE_NAM}"
+		
+		# Download the `flight` file archive
+		if ! [ -e "${flite_archive}" ];
+		then
+			wget "${FLITE_ARCHIVE_URL}" -O "${flite_archive}"
+		fi
+		
+		# Verify the archive's integrity
+		echo "${FLITE_ARCHIVE_MD5}  ${flite_archive}" | md5sum --check -
+		
+		# Extract the `flight` file archive
+		tar -C "${FLITE_BUILD_DIR}" -xvf "${flite_archive}"
+		
+		# Patch `flight` configure script to work with newer versions of the NDK (10e – 11c tested)
+		cd "${flite_directory}"
+		echo "${FLITE_PATCH}" | patch -p 1
+		autoreconf
+		cd "${OLDPWD}"
+		
+	fi
+	
+	export FLITEDIR="${flite_directory}"
+fi
+
+# Build `flight` engine for all supported targets
+cd "${FLITEDIR}"
+for arch in armeabi armeabiv7a x86 mips;
+do
+	if ! [ -e "${FLITEDIR}/build/${arch}-android/lib/libflite.a" ];
+	then
+		./configure --with-langvox=android --target="${arch}-android"
+		make -j4
+	fi
+done
+cd "${OLDPWD}"
+
+# Build the Android application package
+if [ $# -gt 0 ];
+then
+	action="${1}"
+	shift 1
+else
+	action="debug"
+fi
+ant "${action}" "$@"

--- a/build.xml
+++ b/build.xml
@@ -33,6 +33,9 @@
          This must be done before we load project.properties since
          the proguard config can use sdk.dir -->
     <property environment="env" />
+    <condition property="sdk.dir" value="${env.ANDROID_SDK}">
+        <isset property="env.ANDROID_SDK" />
+    </condition>
     <condition property="sdk.dir" value="${env.ANDROID_HOME}">
         <isset property="env.ANDROID_HOME" />
     </condition>
@@ -42,6 +45,9 @@
 
     <condition property="ndk.dir" value="${env.ANDROID_NDK}">
         <isset property="env.ANDROID_NDK" />
+    </condition>
+    <condition property="ndk.dir" value="${env.ANDROID_NDK_HOME}">
+        <isset property="env.ANDROID_NDK_HOME" />
     </condition>
 
     <!-- The project.properties file is created and updated by the 'android'

--- a/project.properties
+++ b/project.properties
@@ -10,4 +10,4 @@
 # Indicates whether an apk should be generated for each density.
 split.density=false
 # Project target.
-target=android-16
+target=android-22


### PR DESCRIPTION
Fixes #46 and #47.
